### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ifupdown-multi (0.1.2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:43:12 +0100
+
 ifupdown-multi (0.1.1) unstable; urgency=low
 
   * Initial release. (Closes: #724452)

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Robert S. Edmonds <edmonds@debian.org>
 Build-Depends: debhelper (>= 9), python
 Standards-Version: 3.9.4
-Vcs-Git: git://github.com/farsightsec/ifupdown-multi.git
+Vcs-Git: https://github.com/farsightsec/ifupdown-multi.git
 Vcs-Browser: https://github.com/farsightsec/ifupdown-multi
 
 Package: ifupdown-multi


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
